### PR TITLE
Do not fail silently, if SCIP fails

### DIFF
--- a/source/normalizedThinFlowClass.py
+++ b/source/normalizedThinFlowClass.py
@@ -94,6 +94,8 @@ class NormalizedThinFlow:
         if PRINT_TO_CONSOLE:
             # Print stdout to terminal
             print(stdOut)
+        if stdErr is not None:
+            print(stdErr)
 
     def write_zimpl_files(self):
         """Write the ZIMPL files"""


### PR DESCRIPTION
I had a broken SCIP setup and NFC failed silently when starting the Nash Flow Computation (because of a missing outputLog).
It would have helped me finding my mistake quicker, if I could have seen SCIP's error.